### PR TITLE
Implement overrides for file parser

### DIFF
--- a/score/init/initializer.py
+++ b/score/init/initializer.py
@@ -172,7 +172,9 @@ def init_from_file(file, *, overrides={}, init_logging=True):
     See the documentation of :func:`.init` for a description of all keyword
     arguments.
     """
-    return init(parse_config_file(file, return_configparser=init_logging),
+    return init(parse_config_file(file,
+                                  return_configparser=init_logging,
+                                  overrides=overrides),
                 overrides=overrides,
                 init_logging=init_logging)
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 
 setup(
     name='score.init',
-    version='0.5.9',
+    version='0.5.10a0',
     description='Automatic initialization of The SCORE Framework',
     long_description=README,
     author='strg.at',


### PR DESCRIPTION
Implements that "include" and "based_on" keys in section "score.init" of an override dictionary provided to the init_from_file functions are no longer ignored.